### PR TITLE
Adição da função usleep para evitar enumeracao time-based.

### DIFF
--- a/hardesec.php
+++ b/hardesec.php
@@ -34,6 +34,9 @@
   // Configurar o tamanho da resposta
   header('Content-Length: ' . strlen($respostaQuebrada));
 
+  // Sleep para randomizar o tempo de resposta e evitar enumeracao time-based
+  usleep(mt_rand(200, 400000));
+
   // Exibe o cabeçalho do documento HTML
   echo "<!DOCTYPE html>
 <html>


### PR DESCRIPTION
Sem a utilização da função usleep, o tempo de resposta é sempre baixo. Sendo possível a enumeração com base no tempo de resposta. Exemplos:

<img width="120" alt="image" src="https://github.com/ricardolongatto/hardesec/assets/65719398/2e3fbf55-3e16-4ddc-8c5e-e8b69864cb63"><br>

<img width="122" alt="image" src="https://github.com/ricardolongatto/hardesec/assets/65719398/038e67dc-ae04-4327-944a-5fb0798b1234"><br>

<img width="118" alt="image" src="https://github.com/ricardolongatto/hardesec/assets/65719398/4344cf6e-f076-4a41-b4d3-9aeac42bfeb3">


Com a utilização do usleep temos um cenário diferente:
<img width="133" alt="image" src="https://github.com/ricardolongatto/hardesec/assets/65719398/2411fd93-6d84-493a-aafb-03ca44cd2a99"><br>

<img width="115" alt="image" src="https://github.com/ricardolongatto/hardesec/assets/65719398/8695c7b6-2af0-40bf-bc5b-c1de7d91f5af"><br>

<img width="123" alt="image" src="https://github.com/ricardolongatto/hardesec/assets/65719398/861c34b2-e8cc-415c-b061-a4bae699d8f4">






